### PR TITLE
Gestures: allow to set back swipe deadzone [1/2]

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -4803,6 +4803,23 @@ public final class Settings {
         public static final String VOLBTN_MUSIC_CONTROLS = "volbtn_music_controls";
 
         /**
+         * Set edge gesture Y dead zone
+         * 0 - disabled - stock behavior - default
+         * 1 - smaller top area of the screen
+         * 2 - small top area of the screen
+         * 3 - half top of the screen
+         * @hide
+         */
+        public static final String EDGE_GESTURE_Y_DEAD_ZONE = "edge_gesture_y_dead_zone";
+
+        /**
+         * IMPORTANT: If you add a new public settings you also have to add it to
+         * PUBLIC_SETTINGS below. If the new setting is hidden you have to add
+         * it to PRIVATE_SETTINGS below. Also add a validator that can validate
+         * the setting value. See an example above.
+         */
+
+        /**
          * Keys we no longer back up under the current schema, but want to continue to
          * process when restoring historical backup datasets.
          *

--- a/core/java/com/android/internal/policy/GestureNavigationSettingsObserver.java
+++ b/core/java/com/android/internal/policy/GestureNavigationSettingsObserver.java
@@ -71,6 +71,9 @@ public class GestureNavigationSettingsObserver extends ContentObserver {
                 DeviceConfig.NAMESPACE_SYSTEMUI,
                 runnable -> mMainHandler.post(runnable),
                 mOnPropertiesChangedListener);
+        r.registerContentObserver(
+                Settings.System.getUriFor(Settings.System.EDGE_GESTURE_Y_DEAD_ZONE),
+                false, this, UserHandle.USER_ALL);
     }
 
     public void unregister() {
@@ -113,5 +116,27 @@ public class GestureNavigationSettingsObserver extends ContentObserver {
         final float scale = Settings.Secure.getFloatForUser(
                 mContext.getContentResolver(), side, 1.0f, UserHandle.USER_CURRENT);
         return (int) (inset * scale);
+    }
+
+    public int getDeadZoneMode() {
+        int mode = Settings.System.getIntForUser(mContext.getContentResolver(),
+            Settings.System.EDGE_GESTURE_Y_DEAD_ZONE, 0,
+            UserHandle.USER_CURRENT);
+        int divider = 0;
+        switch (mode) {
+            default:
+                divider = 0; // mode set to 0, back gesture working on the whole edge
+                break;
+            case 1: // mode set to 1
+                divider = 4;
+                break;
+            case 2: // mode set to 2
+                divider = 3;
+                break;
+            case 3: // mode set to 3, back gesture working only in the half bottom edge
+                divider = 2;
+                break;
+        }
+        return divider;
     }
 }

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/EdgeBackGestureHandler.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/EdgeBackGestureHandler.java
@@ -169,6 +169,8 @@ public class EdgeBackGestureHandler extends CurrentUserTracker implements Displa
     private int mEdgeWidthRight;
     // The bottom gesture area height
     private float mBottomGestureHeight;
+    // Displaysize divider to check the edge height where touch down is allowed
+    private int mYDeadzoneDivider = 0;
     // The slop to distinguish between horizontal and vertical motion
     private float mTouchSlop;
     // Duration after which we consider the event as longpress.
@@ -288,6 +290,8 @@ public class EdgeBackGestureHandler extends CurrentUserTracker implements Displa
         mEdgeWidthRight = mGestureNavigationSettingsObserver.getRightSensitivity(res);
         mIsBackGestureAllowed =
                 !mGestureNavigationSettingsObserver.areNavigationButtonForcedVisible();
+
+        mYDeadzoneDivider = mGestureNavigationSettingsObserver.getDeadZoneMode();
 
         final DisplayMetrics dm = res.getDisplayMetrics();
         final float defaultGestureHeight = res.getDimension(
@@ -553,6 +557,10 @@ public class EdgeBackGestureHandler extends CurrentUserTracker implements Displa
         // mLogGesture = false.
         if (x > 2 * (mEdgeWidthLeft + mLeftInset)
                 && x < (mDisplaySize.x - 2 * (mEdgeWidthRight + mRightInset))) {
+            return false;
+        }
+
+        if (mYDeadzoneDivider != 0 && y < (mDisplaySize.y / mYDeadzoneDivider)) {
             return false;
         }
 


### PR DESCRIPTION
so it's easier to open apps left drawer or avoid unwanted back swipes
when using gallery apps

Change-Id: I805941e7b9de44f3ffdb115ccaad9fa8c0712576
Signed-off-by: spezi77 <spezi7713@gmx.net>
Signed-off-by: Joey Huab <joey@evolution-x.org>